### PR TITLE
Tremolo Depth parameter

### DIFF
--- a/src/effects/native/tremoloeffect.cpp
+++ b/src/effects/native/tremoloeffect.cpp
@@ -127,12 +127,12 @@ TremoloEffect::~TremoloEffect() {
 }
 
 void TremoloEffect::processChannel(const ChannelHandle& handle,
-                                TremoloGroupState* pState,
-                                const CSAMPLE* pInput, CSAMPLE* pOutput,
-                                const unsigned int numSamples,
-                                const unsigned int sampleRate,
-                                const EffectProcessor::EnableState enableState,
-                                const GroupFeatureState& groupFeatures) {
+                                   TremoloGroupState* pState,
+                                   const CSAMPLE* pInput, CSAMPLE* pOutput,
+                                   const unsigned int numSamples,
+                                   const unsigned int sampleRate,
+                                   const EffectProcessor::EnableState enableState,
+                                   const GroupFeatureState& groupFeatures) {
     Q_UNUSED(handle);
 
     const double shape = m_pShapeParameter->value();

--- a/src/effects/native/tremoloeffect.cpp
+++ b/src/effects/native/tremoloeffect.cpp
@@ -184,7 +184,7 @@ void TremoloEffect::processChannel(const ChannelHandle& handle,
         positionFrame = positionFrame % framePerPeriod;
 
         //  Relative position (0 to 1) in the period
-        double position = 1.0 * positionFrame / framePerPeriod;
+        double position = static_cast<double>(positionFrame) / framePerPeriod;
 
         //  Bend the position according to the shape parameter
         //  This maps [0 shape] to [0 0.5] and [shape 1] to [0.5 1]

--- a/src/effects/native/tremoloeffect.h
+++ b/src/effects/native/tremoloeffect.h
@@ -39,6 +39,7 @@ class TremoloEffect : public PerChannelEffectProcessor<TremoloGroupState> {
         return getId();
     }
 
+    EngineEffectParameter* m_pDepthParameter;
     EngineEffectParameter* m_pRateParameter;
     EngineEffectParameter* m_pShapeParameter;
     EngineEffectParameter* m_pWaveformParameter;


### PR DESCRIPTION
This allows for smoothly bringing the effect in and out of a mix more easily. Previously the effect had to be disabled exactly at the peak volume to turn it off smoothly.